### PR TITLE
Idle Miner Background VBS

### DIFF
--- a/IdleMiner Background Run.vbs
+++ b/IdleMiner Background Run.vbs
@@ -1,0 +1,12 @@
+Dir = "PATH TO Directory WITH IDLEMINER AND THE MINER OF CHOICE"
+strComputer = "."
+Set objWMIService = GetObject("winmgmts:" _
+& "{impersonationLevel=impersonate}!\\" & strComputer & "\root\cimv2")
+Set colProcesses = objWMIService.ExecQuery _
+("Select * from Win32_Process Where Name = 'IdleMiner.exe'")
+if colProcesses.Count = 0 Then
+Set WshShell = WScript.CreateObject("WScript.Shell")
+WshShell.CurrentDirectory = theDir
+WshShell.Run "IdleMiner.exe",1,false
+End If
+WSCript.Quit


### PR DESCRIPTION
This script is designed to run IdleMiner completely in the background. It works with XMRig, Aeon Stak CPU and with XMR Stak. Just edit the script with Notepad and type in the path to the directory that contains Idle Miner. It will launch Idle Miner in the background. All other operations remain the same.